### PR TITLE
Add env BIND_IP

### DIFF
--- a/docker-scripts/gremlin-server-3.0.0/files/default_cmd
+++ b/docker-scripts/gremlin-server-3.0.0/files/default_cmd
@@ -5,7 +5,7 @@ env
 IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
 echo "IP=$IP"
 
-sed -i "s|^host:.*|host: $IP|" /opt/gremlin-server/conf/gremlin-server.yaml
+sed -i "s|^host:.*|host: ${BIND_IP:-IP}|" /opt/gremlin-server/conf/gremlin-server.yaml
 
 mkdir /var/run/sshd
 


### PR DESCRIPTION
If u want allow external connections without modify Dockerfile tinkerpop/gremlin-server and rebuild image, u just assign IP to environment variable BIND_IP

```yml
...
environment:
      - BIND_IP=0.0.0.0
...
```